### PR TITLE
fix: context-menu encoding

### DIFF
--- a/chrome/views/background.pug
+++ b/chrome/views/background.pug
@@ -2,4 +2,4 @@ doctype html
 
 html
   head
-    script(src=env == 'prod' ? '/js/background.bundle.js' : 'http://localhost:3000/js/background.bundle.js')
+    script(src=env == 'prod' ? '/js/background.bundle.js' : 'http://localhost:3000/js/background.bundle.js', charset='UTF-8')


### PR DESCRIPTION
Workaround para solucionar o issue #24 
Adiciona o charset ao include do script de background.